### PR TITLE
XE 19.1 bug fix

### DIFF
--- a/CuXtom Cam Library/src/com/glass/cuxtomcam/CuxtomCamActivity.java
+++ b/CuXtom Cam Library/src/com/glass/cuxtomcam/CuxtomCamActivity.java
@@ -427,6 +427,9 @@ public class CuxtomCamActivity extends Activity implements BaseListener,
 				dir.mkdirs();
 			}
 			videofile = new File(dir, fileName + ".mp4");
+			
+			// Step 1: Unlock camera
+			mCamera.unlock();
 			recorder.setCamera(mCamera);
 
 			// Step 2: Set sources


### PR DESCRIPTION
Was getting error (-38, 0) from MediaPlayer. This is fixed by unlocking the camera prior to use. :)
